### PR TITLE
fix: all position instances are same

### DIFF
--- a/Include/MQL5-JSON_API/Broker.mqh
+++ b/Include/MQL5-JSON_API/Broker.mqh
@@ -26,7 +26,8 @@ void GetPositions(CJAVal &dataObject)
      {
       mControl.mResetLastError();
 
-      if(myposition.Select(PositionGetSymbol(i)))
+      //if(myposition.Select(PositionGetSymbol(i)))
+      if(myposition.SelectByIndex(i))
         {
          position["id"]=PositionGetInteger(POSITION_IDENTIFIER);
          position["magic"]=PositionGetInteger(POSITION_MAGIC);


### PR DESCRIPTION
by having multiple positions on usd/eur, i have encounterd that all position are copy of first position. this fix it.

and in concurrent scenarios with asyncio, zmq responses mixed up. i added req_id to all requests. should i send this feature pull request?